### PR TITLE
Use 'exit' animation shorthand in example

### DIFF
--- a/guides/neon-animation.md
+++ b/guides/neon-animation.md
@@ -109,7 +109,7 @@ Polymer({
   hide: function() {
     this.opened = false;
     // run fade-out-animation
-    this.playAnimation('fade-out-animation');
+    this.playAnimation('exit');
   },
   _onNeonAnimationFinish: function() {
     if (!this.opened) {


### PR DESCRIPTION
I think the intention here was to use `entry` and `exit` shorthands in the `playAnimation` calls.
